### PR TITLE
add a default case to allow for non-import conditional

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": {
       "types": "./lib/stellar-hd-wallet.d.ts",
-      "import": "./lib/stellar-hd-wallet.js"
+      "import": "./lib/stellar-hd-wallet.js",
+      "default": "./lib/stellar-hd-wallet.js"
     }
   },
   "files": [


### PR DESCRIPTION
Thanks for the latest update! 

I did notice one issue when upgrading to the latest: if you try to import stellar-hd-wallet using `require`, you hit a [ERR_PACKAGE_PATH_NOT_EXPORTED](https://nodejs.org/api/errors.html#err_package_path_not_exported) error in node and the library will not load. 

I ran into this when trying to run some e2e tests using Playwright (it appears Playwright forces the use of `require` in its deps under the hood). To get around this, you can set a `default` key in `exports` at the bottom. Node engines will try all the paths above it, and if all else fails, it will use the path defined in `default`.

Additional context: https://nodejs.org/api/packages.html#conditional-exports